### PR TITLE
Incorporate non-negative KNN mutual information score estimation 

### DIFF
--- a/R/calEdgeCorScore.R
+++ b/R/calEdgeCorScore.R
@@ -1,4 +1,4 @@
-calEdgeCorScore <- function(dataset, class.labels,controlcharactor, edgesbackgrand) {
+calEdgeCorScore <- function(dataset, class.labels,controlcharactor, edgesbackgrand, k=3, k_iter_max=10) {
 #This function calculate differential Mutual information
 #Inputs:
 #     dataset: Marix of gene expression values (rownames are genes, columnnames are samples) 
@@ -19,7 +19,15 @@ calEdgeCorScore <- function(dataset, class.labels,controlcharactor, edgesbackgra
 	   Cexpress.2<-dataset[location[,2],controlloca]
 	   EdgeCorScore<-c()
 	   for(i in 1:length(location[,1])){
-		   EdgeCorScore[i]<-knnmi(dataset.1[i,],dataset.2[i,])-knnmi(Cexpress.1[i,],Cexpress.2[i,])
+	   		dataset_1_dis = arules::discretize(x=as.numeric(dataset.1[i,]), method="cluster", centers=k,iter.max=k_iter_max)
+			dataset_2_dis = arules::discretize(x=as.numeric(dataset.2[i,]), method="cluster", centers=k,iter.max=k_iter_max)
+			dataset_MI = infotheo::mutinformation(dataset_1_dis,dataset_2_dis)
+
+			Cexpress_1_dis = arules::discretize(x=as.numeric(Cexpress.1[i,]), method="cluster", centers=k,iter.max=k_iter_max)
+			Cexpress_2_dis = arules::discretize(x=as.numeric(Cexpress.2[i,]), method="cluster", centers=k,iter.max=k_iter_max)
+			Cexpress_MI = infotheo::mutinformation(Cexpress_1_dis,Cexpress_2_dis)
+
+		   	EdgeCorScore[i]<-dataset_MI-Cexpress_MI
 		  }   
 		EdgeID<-matrix(0,length(location[,1]),2)
 		EdgeID[,1]<-row.names(dataset.1)

--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ News:
 * Fixed an issue in the MI score calculation where negative values were returned. The functions arules::discretize now 
 provides the k-nearest neighbors clustering and discretization and infotheo::mutinformation now performs the MI score
 calculation.
+* Authors of Nature paper haven't responded to repeated emails (Mar 2019).
 
 ESEA — ESEA: Discovering the Dysregulated Pathways based on Edge Set Enrichment Analysis  

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
 # ESEA
 This is Ryan Neff's fork of ESEA at the Bin Zhang lab at Mount Sinai. 
-
-News: 
-* Fixed an issue in the MI score calculation where negative values were returned. The functions arules::discretize now 
-provides the k-nearest neighbors clustering and discretization and infotheo::mutinformation now performs the MI score
-calculation.
-* Authors of Nature paper haven't responded to repeated emails (Mar 2019).
-
 ESEA — ESEA: Discovering the Dysregulated Pathways based on Edge Set Enrichment Analysis  

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# ESEA
+This is Ryan Neff's fork of ESEA at the Bin Zhang lab at Mount Sinai. 
+
+News: 
+* Fixed an issue in the MI score calculation where negative values were returned. The functions arules::discretize now 
+provides the k-nearest neighbors clustering and discretization and infotheo::mutinformation now performs the MI score
+calculation.
+
+ESEA — ESEA: Discovering the Dysregulated Pathways based on Edge Set Enrichment Analysis  


### PR DESCRIPTION
This pull request changes the k-nearest neighbors MI underlying algorithm from one which provides estimates of MI that may sometimes be negative due to bias correction (see [Kraskov et al. 2004](https://journals.aps.org/pre/abstract/10.1103/PhysRevE.69.066138#fulltext)) to one which is always positive. 

The rationale was that 1) MI scores are consistent with certain numerical properties on non-negative matrices; and 2) is possible that the EdgeCorScore is boosted by negative values of the coexpressed MI. However, this pull request eliminates bias correction performed by the algorithm in knnmi() that may be desirable (infotheo::mutualinformation() does provide bias-corrected MI scores as an option, but so far I have not investigated these changes).

